### PR TITLE
observations: Add new column tle_source

### DIFF
--- a/python-files/observations.py
+++ b/python-files/observations.py
@@ -94,6 +94,7 @@ class ObservationsDB(dict):
             tle0 TEXT,
             tle1 TEXT,
             tle2 TEXT,
+            tle_source TEXT,
             center_frequency INTEGER,
             observer INTEGER,
             observation_frequency INTEGER,


### PR DESCRIPTION
A new field `tle_source` was added to `/observations` API with SatNOGS Network release [1.119](https://gitlab.com/librespacefoundation/satnogs/satnogs-network/-/commits/1.119).

[1.119 release announcement](https://community.libre.space/t/satnogs-network-release-1-119/12448)

Migration:
```sql
ALTER TABLE observations ADD COLUMN tle_source TEXT;
```